### PR TITLE
Tweak rollup config - prevent circular _typeof babel helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -187,7 +187,6 @@
   "homepage": "https://jcubic.github.io/open-source-library/",
   "devDependencies": {
     "@babel/core": "^7.0.1",
-    "@babel/plugin-external-helpers": "^7.0.0",
     "@babel/plugin-transform-async-to-generator": "^7.0.0",
     "@babel/plugin-transform-runtime": "^7.0.0",
     "@babel/preset-env": "^7.0.0",
@@ -202,7 +201,6 @@
     "rollup-plugin-babel": "^4.0.3",
     "rollup-plugin-commonjs": "^9.1.6",
     "rollup-plugin-node-resolve": "^3.4.0",
-    "rollup-plugin-replace": "^2.0.0",
     "uglify-js": "^3.3.12"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,7 +1,6 @@
 import commonjs from "rollup-plugin-commonjs";
 import nodeResolve from "rollup-plugin-node-resolve";
 import babel from "rollup-plugin-babel";
-import replace from "rollup-plugin-replace";
 
 export default {
     input: "src/main.js",
@@ -15,30 +14,20 @@ export default {
             include: "node_modules/**"
         }),
         nodeResolve({
-          jsnext: true,
-          main: false
+            jsnext: true,
+            main: false
         }),
         babel({
             "babelrc": false,
             "runtimeHelpers": true,
             "plugins": [
-                "syntax-async-functions",
-                "@babel/plugin-external-helpers",
                 "@babel/plugin-transform-async-to-generator",
-                ["@babel/plugin-transform-runtime", {
-                    //"helpers": true,
-                    "regenerator": true
-                }]
+                ["@babel/plugin-transform-runtime", {useESModules: true}]
             ],
             "presets": [
                 "@babel/preset-env"
-            ]
-        }),
-        // fix for a bug in Babel or rollup babel plugin rollup/rollup-plugin-babel#252
-        replace({
-            delimiters: ["", ""],
-            "_typeof2(Symbol.iterator)": "typeof Symbol.iterator",
-            "_typeof2(obj);": "typeof obj;"
+            ],
+            "exclude": "node_modules/**"
         })
     ]
 };


### PR DESCRIPTION
Aside of those changes - I would encourage you to tweak ur setup in several ways.

For starters:
1. unify babel config - remove `babel-` deps, use the same, centralized, config for both jest & rollup - this doesnt mean that for both you should pass same plugins/presets, it's just that it's better to have a single source of truth so I would advise avoiding `babelrc: false` in ur rollup
2. build several bundles of your library - with different formats, `"main"` should be a cjs file, `"module"` should point to esm bundle and `"unpkg"` can point to either umd or iife. Avoid iife format when targeting node/bundlers with main/module
3. do not bundle your dependencies for main/module bundles, no tool will be able to dedupe them across the whole consuming project (make use of `external` option of rollup)